### PR TITLE
PLAN-198 fix scrolling to actual stop on LineTimeline screen on ios

### DIFF
--- a/screens/LineTimeline.tsx
+++ b/screens/LineTimeline.tsx
@@ -92,6 +92,7 @@ export default function LineTimeline({
                     })
                 }}
                 onLayout={(event) =>
+                  activeIndex == index &&
                   setElementPosition(event.nativeEvent.layout.y)
                 }
               >


### PR DESCRIPTION
There was just a missing condition i guess, everything works on ios now.