### PR TITLE
feature/PLAN-390 Planner to single URL

### DIFF
--- a/utils/api.ts
+++ b/utils/api.ts
@@ -21,9 +21,6 @@ import {
 const host = 'planner.bratislava.sk'
 const dataHostUrl = Constants.manifest?.extra?.apiHost || `https://live.${host}`
 const otpPlannerUrl = `https://api.${host}/otp/routers/default/plan` // TODO use otp.planner.bratislava.sk
-const otpRekolaPlannerUrl = `https://rekola.${host}/routers/default/plan`
-const otpSlovnaftbajkPlannerUrl = `https://slovnaftbajk.${host}/routers/default/plan`
-const otpTierPlannerUrl = `https://tier.${host}/routers/default/plan`
 
 // we should throw throwables only, so it's useful to extend Error class to contain useful info
 // export class ApiError extends Error {


### PR DESCRIPTION
- changed the planner URL for OTP requests to [https://api.planner.bratislava.sk/](https://api.planner.bratislava.sk/)
- added `allowedVehicleRentalNetworks` parameter to distinguish between different providers